### PR TITLE
ChatGPT with context

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,53 @@
+name: Docker build
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  docker-build-push:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4      
+            
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          logout: true
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+  
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/rlproteus/cloudbot
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      
+      - name: Build and push Docker 
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.12
 
-RUN mkdir /opt/cloudbot
-COPY . /opt/cloudbot
 WORKDIR /opt/cloudbot
+RUN useradd -m cloudbot
+RUN chown -R cloudbot:cloudbot /opt/cloudbot
+USER cloudbot
 
+COPY requirements.txt /opt/cloudbot
 RUN pip install -r requirements.txt
+COPY . /opt/cloudbot
 
 ENTRYPOINT [ "python", "-m", "cloudbot" ]

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -36,15 +36,14 @@ def add_to_rate_limit(nick):
 
 def build_prompt(nick, chan, text):
     global CONTEXT
-    prompt = ""
     if CONTEXT.get("timestamp") is not None:
         time_difference = abs(datetime.now() - CONTEXT.get("timestamp"))
         if time_difference.seconds > 300:
             CONTEXT.clear()
         else:
-            prompt = CONTEXT.get("context")
+            ctx = CONTEXT.get("context")
             return "\n".join([
-                prompt,
+                ctx,
                 f"{nick} on IRC channel {chan} says: {text}"
             ])
     return "\n".join([

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -61,6 +61,11 @@ def set_system_message(nick, chan, text, event):
     SYSTEM = text
     return f"System prompt has been updated to {SYSTEM}"
 
+@hook.command("gpt_drop_context")
+def drop_context():
+    global CONTEXT
+    CONTEXT.clear()
+    return "Context has been dropped !"
 
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):

--- a/plugins/chatgpt.py
+++ b/plugins/chatgpt.py
@@ -12,6 +12,7 @@ import string
 
 RATELIMIT = {}
 SYSTEM = ""
+CONTEXT = {}
 
 def check_rate_limit(nick, event):
     permission_manager = event.conn.permissions
@@ -33,6 +34,24 @@ def add_to_rate_limit(nick):
     RATELIMIT[nick] = datetime.now()
     pass
 
+def build_prompt(nick, chan, text):
+    global CONTEXT
+    prompt = ""
+    if CONTEXT.get("timestamp") is not None:
+        time_difference = abs(datetime.now() - CONTEXT.get("timestamp"))
+        if time_difference.seconds > 300:
+            CONTEXT.clear()
+        else:
+            prompt = CONTEXT.get("context")
+            return "\n".join([
+                prompt,
+                f"{nick} on IRC channel {chan} says: {text}"
+            ])
+    return "\n".join([
+        SYSTEM,
+        f"{nick} on IRC channel {chan} says: {text}"
+    ])
+
 @hook.command("gpt_get_system")
 def get_system_message():
     return f"Current system message: {SYSTEM}"
@@ -46,11 +65,9 @@ def set_system_message(nick, chan, text, event):
 
 @hook.command("gpt", autohelp=False)
 def chat_gpt(nick, chan, text, event):
+    global CONTEXT
     rate_limit = check_rate_limit(nick, event)
-    prompt = "\n".join([
-        SYSTEM,
-        f"{nick} on IRC channel {chan} says: {text}"
-    ])
+    prompt = build_prompt(nick, chan, text)
     open_ai_api_key = bot.config.get_api_key("openai")
     resp = requests.post("https://api.openai.com/v1/chat/completions",
                            headers={
@@ -72,6 +89,10 @@ def chat_gpt(nick, chan, text, event):
     add_to_rate_limit(nick)
     if resp.status_code == 200:
         answer = resp.json()["choices"][0]["message"]["content"].replace("\n","")
+        CONTEXT = {
+            "context": "\n".join([prompt, answer]),
+            "timestamp": datetime.now()
+        }
         messages = textwrap.wrap(answer,420)
         if len(messages) > 3:
             hastebin_api_key = bot.config.get_api_key("hastebin")


### PR DESCRIPTION
This merge requests implements an in-memory context for the ChatGPT plugin. The plugin now stores the user prompt and ChatGPT's answer alongside a timestamp. If a new `.gpt` request  happens, the previous question and answer is prefixed to the new request payload. The context is dropped after 5min. This change would allow user to have discussions with ChatGPT that span over multiple messages. A `.gpt_drop_context` method has also been added to manually drop the context. 

This merge requests also adds minor fixes to the Dockerfile (dedicated user + cache performances) and a GIthub Action pipeline that triggers on `git tag v1.x.x` to build and publish the bot container to ghcr.io